### PR TITLE
Fixed missing margin in the control bar

### DIFF
--- a/app/inject/styles.css
+++ b/app/inject/styles.css
@@ -6,7 +6,7 @@
 .castControl {
     width: 19px;
     height: 46px;
-    margin: 0;
+    margin: 0 0 0 12px;
     padding: 0;
     position: relative;
     transition: box-shadow 200ms;


### PR DESCRIPTION
Fixed missing margin the the control bar.
Instead of showing
![image](https://user-images.githubusercontent.com/17984549/27976281-1bff484e-6366-11e7-97d2-4b4985b087a0.png)
Now displaying:
![image](https://user-images.githubusercontent.com/17984549/27976287-20ecb3d2-6366-11e7-8db8-49fe84750ff6.png)
